### PR TITLE
Use pty for running procs

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -209,7 +209,8 @@ func Test_ClientServerNetcat(t *testing.T) { //nolint:paralleltest // not parall
 		wait.BoolFunc(func() bool {
 			d, err := os.ReadFile(filepath.Join(pmDir, "logs", string(serverID)+".stdout"))
 			test.NoError(t, err, test.Sprint("read server stdout"))
-			return string(d) == "123\n"
+			t.Logf("server logs:\n%q", string(d))
+			return string(d) == "123\r\n"
 		}),
 		wait.Timeout(time.Second*10),
 	), must.Sprint("check server received payload"))

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 require (
 	github.com/charmbracelet/huh v0.5.2
 	github.com/charmbracelet/lipgloss v0.12.1
+	github.com/creack/pty v1.1.24
 	github.com/deref/rgbterm v0.0.0-20220210012105-fe81195c39e7
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/google/go-jsonnet v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/charmbracelet/x/windows v0.1.2 h1:Iumiwq2G+BRmgoayww/qfcvof7W/3uLoelh
 github.com/charmbracelet/x/windows v0.1.2/go.mod h1:GLEO/l+lizvFDBPLIOk+49gdX49L9YWMB5t+DZd0jkQ=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deref/rgbterm v0.0.0-20220210012105-fe81195c39e7 h1:e06GM9EReJNEd3uy3OoTlRJhIdeFWDCjoD2MW4yP5P8=

--- a/internal/cli/impl_start.go
+++ b/internal/cli/impl_start.go
@@ -85,7 +85,7 @@ func startShimImpl(db db.Handle, id core.PMID) error {
 	}
 	log.Debug().Str("cmd", cmd.String()).Msg("starting")
 	if err := cmd.Start(); err != nil {
-		return errors.Wrapf(err, "running failed: %v", proc)
+		return errors.Wrapf(err, "run command: %v", proc)
 	}
 
 	return nil

--- a/internal/core/filter.go
+++ b/internal/core/filter.go
@@ -14,7 +14,7 @@ type filter struct {
 	AllIfNoFilters bool
 }
 
-func (f filter) NoFilters() bool {
+func (f filter) noFilters() bool {
 	return len(f.Names) == 0 &&
 		len(f.Tags) == 0 &&
 		len(f.IDs) == 0
@@ -71,7 +71,7 @@ func FilterFunc(opts ...FilterOption) func(Proc) bool {
 		opt(&_filter)
 	}
 
-	if _filter.NoFilters() {
+	if _filter.noFilters() {
 		return func(Proc) bool {
 			return _filter.AllIfNoFilters
 		}


### PR DESCRIPTION
first, it is required to run js shit which waits for tty and does nothing until gets it
second, it is required for future `attach` feature to connect to proc stdin/stdout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced process handling and I/O management through the integration of pseudo-terminal (PTY) operations.
	- Improved error handling and logging for PTY operations.

- **Bug Fixes**
	- Updated error message for command execution failures to improve clarity.

- **Refactor**
	- Changed method visibility from public to private for better encapsulation.
	- Adjusted expected output format in tests to align with server response changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->